### PR TITLE
Fix imports and PDF handling

### DIFF
--- a/src/document_reader/processor_factory.py
+++ b/src/document_reader/processor_factory.py
@@ -99,8 +99,8 @@ class ProcessorFactory:
             pdf_processor = self._create_processor('pdf')
             
             # 간단한 텍스트 추출 테스트
-            import pymupdf
-            with pymupdf.open(file_path) as doc:
+            import fitz
+            with fitz.open(file_path) as doc:
                 if len(doc) > 0:
                     page = doc[0]
                     text = page.get_text()

--- a/src/document_reader/processors/csv_processor.py
+++ b/src/document_reader/processors/csv_processor.py
@@ -16,12 +16,12 @@ from pydantic import BaseModel, Field, field_validator
 
 from .base_processor import BaseProcessor
 
-from core.exceptions import (
+from ..core.exceptions import (
     CSVError,
     FileSizeError,
     EncodingError,
 )
-from core.models import (
+from ..core.models import (
     CSVAnalysis,
     CSVChunk,
     CSVResult,

--- a/src/document_reader/processors/ocr_processor.py
+++ b/src/document_reader/processors/ocr_processor.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field, ValidationError as PydanticValidationErro
 
 from .base_processor import BaseProcessor
 
-from core.exceptions import (
+from ..core.exceptions import (
     OCRError,
     APIKeyError,
     ProcessingError,

--- a/src/document_reader/processors/pdf_processor.py
+++ b/src/document_reader/processors/pdf_processor.py
@@ -5,7 +5,7 @@ from typing import Dict, Any, List, Optional
 from pathlib import Path
 import time
 
-import pymupdf
+import fitz
 from .base_processor import BaseProcessor
 
 logger = logging.getLogger(__name__)
@@ -83,12 +83,12 @@ class PDFProcessor(BaseProcessor):
         
         # Test PDF validity with PyMuPDF
         try:
-            with pymupdf.open(file_path) as test_doc:
+            with fitz.open(file_path) as test_doc:
                 if test_doc.is_encrypted:
                     return "Password-protected PDFs not supported"
                 if len(test_doc) == 0:
                     return "PDF contains no pages"
-        except pymupdf.FileDataError:
+        except fitz.FileDataError:
             return "Corrupted or invalid PDF file"
         except Exception as e:
             return f"PDF validation error: {str(e)}"
@@ -108,7 +108,7 @@ class PDFProcessor(BaseProcessor):
             }
             
             # 검색 결과 [9] 방식 참고
-            with pymupdf.open(file_path) as doc:
+            with fitz.open(file_path) as doc:
                 result['page_count'] = len(doc)
                 
                 # Extract metadata
@@ -154,7 +154,7 @@ class PDFProcessor(BaseProcessor):
                 result['success'] = True
                 return result
                 
-        except pymupdf.FileDataError as e:
+        except fitz.FileDataError as e:
             return {
                 'success': False,
                 'error': f"PDF file is corrupted or invalid: {str(e)}"
@@ -210,7 +210,7 @@ class PDFProcessor(BaseProcessor):
 
         # Add warnings if any
         if result['warnings']:
-            markdown += f"\n## Processing Notes\n"
+            markdown += "\n## Processing Notes\n"
             for warning in result['warnings']:
                 markdown += f"- {warning}\n"
 


### PR DESCRIPTION
## Summary
- fix relative imports in CSV/OCR processors
- switch PDF modules from `pymupdf` to `fitz`
- fix stray f-string in PDF processor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f4785af4832284a9cba5a175d170