### PR TITLE
Initialize logging via setup call

### DIFF
--- a/src/document_reader/processors/ocr_processor.py
+++ b/src/document_reader/processors/ocr_processor.py
@@ -23,8 +23,7 @@ from ..core.exceptions import (
     ValidationError
 )
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Logger for this module (configured via ``setup_logging()`` below)
 logger = logging.getLogger(__name__)
 
 class JsonFormatter(logging.Formatter):
@@ -790,3 +789,7 @@ class OCRProcessor(BaseProcessor):
                 extra={"page_num": page_num, "error_type": type(e).__name__}
             )
             return Exception(f"Error processing page {page_num}: {str(e)}")
+
+
+# Initialize logging when the module is imported
+setup_logging()


### PR DESCRIPTION
## Summary
- remove direct `logging.basicConfig` usage
- automatically invoke `setup_logging()` when `ocr_processor` is imported
- clarify comment about logger initialization

## Testing
- `ruff check src`

------
https://chatgpt.com/codex/tasks/task_e_6846f732fd60832281bf6d7def040fdd