### PR TITLE
Replace PyMuPDF imports with fitz

### DIFF
--- a/src/document_reader/processor_factory.py
+++ b/src/document_reader/processor_factory.py
@@ -3,6 +3,7 @@
 from typing import Dict, Type, Optional, List, Any
 from pathlib import Path
 import logging
+import fitz
 
 from .processors.base_processor import BaseProcessor
 from .processors.csv_processor import CSVProcessor
@@ -99,7 +100,6 @@ class ProcessorFactory:
             pdf_processor = self._create_processor('pdf')
             
             # 간단한 텍스트 추출 테스트
-            import fitz
             with fitz.open(file_path) as doc:
                 if len(doc) > 0:
                     page = doc[0]

--- a/src/document_reader/processors/pdf_processor.py
+++ b/src/document_reader/processors/pdf_processor.py
@@ -81,7 +81,7 @@ class PDFProcessor(BaseProcessor):
         if file_size_mb > self.max_file_size_mb:
             return f"File too large: {file_size_mb:.1f}MB > {self.max_file_size_mb}MB"
         
-        # Test PDF validity with PyMuPDF
+        # Test PDF validity with fitz (PyMuPDF)
         try:
             with fitz.open(file_path) as test_doc:
                 if test_doc.is_encrypted:


### PR DESCRIPTION
## Summary
- ensure `fitz` is imported in `processor_factory` and use it for PDF detection
- clarify PDF validation comment in `PDFProcessor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f73036088322b24c6dd3e528c905