### PR TITLE
Translate comments to English and add bilingual docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
-# universal-file-reader-mcp
-MCP server that converts data to machine-readable format
-
-## Running Tests
-
-Install dependencies and run the test suite using [pytest](https://pytest.org):
-
-```bash
-pytest
-=======
 # Universal File Reader MCP
 
-This project provides an MCP server capable of extracting information from PDF, CSV and image files. The server automatically selects the best processor for each file and can fall back to OCR when needed.
+Universal File Reader is an MCP server for extracting text and structural information from PDF, CSV and image files. The server automatically selects the appropriate processor and can fall back to OCR when needed.
 
 ## Installation
 
@@ -18,25 +8,28 @@ This project provides an MCP server capable of extracting information from PDF, 
 pip install -e .
 ```
 
-## Usage
-
-Run the MCP server using the provided console script:
+## Running the server
 
 ```bash
 universal-file-reader
 ```
 
-The server exposes tools for reading files and validating them. See `src/document_reader/mcp_server.py` for details.
+The server exposes three tools: `read_file`, `get_supported_formats` and `validate_file`. See `src/document_reader/mcp_server.py` for detailed schemas.
 
-## Environment
+## Environment variables
 
-Some processors require additional configuration:
+- `GOOGLE_API_KEY` – API key used for Gemini based OCR processing.
 
-- `GOOGLE_API_KEY` – API key for Gemini based OCR.
+## Running tests
+
+Install dependencies and run the test suite:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
 
 ## Development
-
-Install development dependencies and run lint checks:
 
 ```bash
 pip install -e .[development]

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,0 +1,37 @@
+# Universal File Reader MCP
+
+Universal File Reader는 PDF, CSV, 이미지 파일에서 정보를 추출하는 MCP 서버입니다. 서버는 파일 형식에 맞는 프로세서를 자동으로 선택하며 필요 시 OCR을 사용합니다.
+
+## 설치
+
+```bash
+pip install -e .
+```
+
+## 서버 실행
+
+```bash
+universal-file-reader
+```
+
+서버는 `read_file`, `get_supported_formats`, `validate_file` 세 가지 도구를 제공합니다. 자세한 입력 형식은 `src/document_reader/mcp_server.py`를 참고하세요.
+
+## 환경 변수
+
+- `GOOGLE_API_KEY` – Gemini 기반 OCR 사용을 위한 API 키
+
+## 테스트 실행
+
+의존성을 설치한 뒤 다음 명령으로 테스트를 실행합니다.
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+## 개발
+
+```bash
+pip install -e .[development]
+ruff check
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,34 +1,34 @@
-# MCP 서버 관련
+# MCP server
 mcp>=1.0.0
 
-# 데이터 처리
+# Data processing
 pandas>=2.0.0
 numpy>=1.24.0
 
-# PDF 처리
+# PDF handling
 pymupdf>=1.23.0
 pdf2image>=3.1.0
 
-# 이미지 처리
+# Image handling
 Pillow>=10.0.0
 
-# OCR 및 AI
+# OCR and AI
 google-generativeai>=0.3.0
 
-# 파일 타입 감지
+# File type detection
 python-magic>=0.4.27
 chardet>=5.2.0
 
-# 비동기 처리
+# Async helpers
 asyncio-throttle>=1.0.0
 
-# 데이터 검증
+# Data validation
 pydantic>=2.5.0
 
-# 로깅
+# Logging
 structlog>=23.0.0
 
-# 개발 의존성 (선택사항)
+# Development dependencies (optional)
 pytest>=7.4.0
 pytest-asyncio>=0.21.0
 black>=23.0.0

--- a/src/document_reader/__init__.py
+++ b/src/document_reader/__init__.py
@@ -1,62 +1,63 @@
-"""Universal File Reader - 범용 파일 처리 MCP 서버
+"""Universal File Reader - multi format processing MCP server.
 
-PDF, CSV, 이미지 파일에서 텍스트, 표, 그래프 등을 추출하는 MCP 서버입니다.
+This package provides an MCP server capable of extracting text, tables and
+images from PDF, CSV and image files.
 """
 
 __version__ = "1.0.0"
 __author__ = "Document Reader Team"
-__description__ = "범용 파일 처리 MCP 서버"
+__description__ = "Universal File Processing MCP server"
 
-# 메인 컴포넌트 임포트
+# Import main components
 from .processor_factory import ProcessorFactory, process_file, get_default_factory
 from .mcp_server import UniversalFileReaderMCP, main as run_server
 
-# 설정 및 유틸리티
+# Configuration and utilities
 from .core.config import ProcessorConfig, GlobalConfig, CSVConfig, OCRConfig, PDFConfig
 from .core.logging_config import setup_logging, get_logger
 from .core.validators import FileValidator, SecurityValidator
 from .core.exceptions import DocumentProcessorError, FileError, CSVError, OCRError, PDFError
 
-# 프로세서들
+# Processors
 from .processors.base_processor import BaseProcessor
 from .processors.csv_processor import CSVProcessor
 from .processors.pdf_processor import PDFProcessor
 from .processors.ocr_processor import OCRProcessor
 
 __all__ = [
-    # 버전 정보
+    # Version info
     "__version__",
     "__author__",
     "__description__",
     
-    # 메인 기능
+    # Main features
     "ProcessorFactory",
     "process_file",
     "get_default_factory",
     "UniversalFileReaderMCP",
     "run_server",
     
-    # 설정
+    # Configuration
     "ProcessorConfig",
     "GlobalConfig", 
     "CSVConfig",
     "OCRConfig",
     "PDFConfig",
     
-    # 유틸리티
+    # Utilities
     "setup_logging",
     "get_logger",
     "FileValidator",
     "SecurityValidator",
     
-    # 예외
+    # Exceptions
     "DocumentProcessorError",
     "FileError",
     "CSVError", 
     "OCRError",
     "PDFError",
     
-    # 프로세서
+    # Processor classes
     "BaseProcessor",
     "CSVProcessor",
     "PDFProcessor",
@@ -65,16 +66,16 @@ __all__ = [
 
 
 def get_version() -> str:
-    """버전 정보를 반환합니다."""
+    """Return package version."""
     return __version__
 
 
 def get_supported_extensions() -> list[str]:
-    """지원하는 파일 확장자 목록을 반환합니다."""
+    """Return list of supported file extensions."""
     factory = get_default_factory()
     return factory.get_supported_extensions()
 
 
 def quick_process(file_path: str, output_format: str = "markdown") -> dict:
-    """빠른 파일 처리를 위한 편의 함수입니다."""
+    """Convenience helper for quick file processing."""
     return process_file(file_path, output_format)

--- a/src/document_reader/processor_factory.py
+++ b/src/document_reader/processor_factory.py
@@ -1,4 +1,4 @@
-"""프로세서 팩토리 및 관리자"""
+"""Processor factory and manager."""
 
 from typing import Dict, Type, Optional, List, Any
 from pathlib import Path
@@ -22,7 +22,7 @@ logger = get_logger("processor_factory")
 
 
 class ProcessorFactory:
-    """프로세서 팩토리 클래스"""
+    """Processor factory class."""
     
     def __init__(self, config: Optional[ProcessorConfig] = None):
         self.config = config or ProcessorConfig.from_env()
@@ -35,98 +35,98 @@ class ProcessorFactory:
         self._extension_mapping = self._build_extension_mapping()
         
     def _build_extension_mapping(self) -> Dict[str, str]:
-        """파일 확장자와 프로세서 타입 매핑을 구축합니다."""
+        """Build mapping between file extensions and processor types."""
         mapping = {}
         
-        # CSV 파일들
+        # CSV files
         for ext in ['.csv', '.tsv']:
             mapping[ext] = 'csv'
             
-        # PDF 파일들 - OCR과 PDF 프로세서 중 선택
-        mapping['.pdf'] = 'auto'  # 자동 선택
+        # PDF files - choose between OCR and PDF processor
+        mapping['.pdf'] = 'auto'  # choose automatically
         
-        # 이미지 파일들
+        # Image files
         for ext in ['.png', '.jpg', '.jpeg', '.bmp', '.tiff', '.tif', '.webp']:
             mapping[ext] = 'ocr'
             
         return mapping
     
     def get_processor(self, file_path: str, force_type: Optional[str] = None) -> BaseProcessor:
-        """파일에 적합한 프로세서를 반환합니다."""
+        """Return a processor suitable for the file."""
         try:
-            # 파일 기본 검증
+            # Basic file validation
             validation_result = FileValidator.validate_file_basic(file_path)
             if not validation_result["is_valid"]:
-                raise FileTypeError(f"파일 검증 실패: {', '.join(validation_result['errors'])}")
+                raise FileTypeError(f"File validation failed: {', '.join(validation_result['errors'])}")
             
-            # 보안 검증
+            # Security validation
             security_result = SecurityValidator.validate_security(file_path)
             if not security_result["is_safe"]:
-                raise FileTypeError(f"보안 검증 실패: {', '.join(security_result['security_warnings'])}")
+                raise FileTypeError(f"Security validation failed: {', '.join(security_result['security_warnings'])}")
             
-            # 프로세서 타입 결정
+            # Determine processor type
             processor_type = force_type or self._determine_processor_type(file_path)
             
-            # 프로세서 생성 또는 반환
+            # Create processor if not cached
             if processor_type not in self._processors:
                 self._processors[processor_type] = self._create_processor(processor_type)
             
             return self._processors[processor_type]
             
         except Exception as e:
-            logger.error(f"프로세서 생성 실패: {e}", extra={"file_path": file_path})
+            logger.error(f"Processor creation failed: {e}", extra={"file_path": file_path})
             raise
     
     def _determine_processor_type(self, file_path: str) -> str:
-        """파일 경로를 기반으로 프로세서 타입을 결정합니다."""
+        """Determine processor type based on file path."""
         extension = Path(file_path).suffix.lower()
         
         if extension not in self._extension_mapping:
-            raise FileTypeError(f"지원하지 않는 파일 형식입니다: {extension}")
+            raise FileTypeError(f"Unsupported file type: {extension}")
         
         processor_type = self._extension_mapping[extension]
         
-        # PDF 파일의 경우 자동 선택
+        # Automatic choice for PDF files
         if processor_type == 'auto' and extension == '.pdf':
             return self._choose_pdf_processor(file_path)
         
         return processor_type
     
     def _choose_pdf_processor(self, file_path: str) -> str:
-        """PDF 파일에 대한 최적 프로세서를 선택합니다."""
+        """Choose the best processor for a PDF file."""
         try:
-            # 먼저 PDF 프로세서로 텍스트 추출 시도
+            # Attempt native PDF text extraction first
             self._create_processor('pdf')
             
-            # 간단한 텍스트 추출 테스트
+            # Simple text extraction test
             with fitz.open(file_path) as doc:
                 if len(doc) > 0:
                     page = doc[0]
                     text = page.get_text()
                     word_count = len(text.split()) if text else 0
                     
-                    # 충분한 텍스트가 있으면 PDF 프로세서 사용
+                    # Use PDF processor if enough text is found
                     if word_count >= self.config.pdf_config.MIN_TEXT_THRESHOLD:
                         logger.info(f"PDF 프로세서 선택: {word_count}개 단어 감지")
                         return 'pdf'
             
-            # 텍스트가 부족하면 OCR 프로세서 사용
+            # Fallback to OCR processor if text is insufficient
             logger.info("OCR 프로세서 선택: 텍스트 부족으로 OCR 필요")
             return 'ocr'
             
         except Exception as e:
-            logger.warning(f"PDF 프로세서 선택 중 오류, OCR 사용: {e}")
+            logger.warning(f"Error choosing PDF processor, using OCR: {e}")
             return 'ocr'
     
     def _create_processor(self, processor_type: str) -> BaseProcessor:
-        """프로세서를 생성합니다."""
+        """Instantiate a processor."""
         if processor_type not in self._processor_types:
             raise ConfigurationError(f"알 수 없는 프로세서 타입: {processor_type}")
         
         processor_class = self._processor_types[processor_type]
         
         try:
-            # 프로세서별 설정 전달
+            # Pass processor specific configuration
             if processor_type == 'csv':
                 return processor_class(self.config.csv_config)
             elif processor_type == 'ocr':
@@ -137,28 +137,28 @@ class ProcessorFactory:
                 return processor_class()
                 
         except Exception as e:
-            logger.error(f"{processor_type} 프로세서 생성 실패: {e}")
+            logger.error(f"Failed to create {processor_type} processor: {e}")
             raise ConfigurationError(f"프로세서 생성 실패: {e}")
     
     def process_file(self, file_path: str, output_format: str = "markdown", 
                     force_processor: Optional[str] = None, **kwargs) -> Dict[str, Any]:
-        """파일을 처리합니다."""
+        """Process a file."""
         import time
         start_time = time.time()
         
         try:
-            # 프로세서 선택
+            # Choose processor
             processor = self.get_processor(file_path, force_processor)
             processor_type = type(processor).__name__
             
-            # 처리 시작 로그
+            # Log start of processing
             log_processing_start(
                 logger, file_path, processor_type,
                 output_format=output_format,
                 force_processor=force_processor
             )
             
-            # 파일 검증 (프로세서별)
+            # Validate file for the processor
             max_size = self.config.get_max_file_size(processor_type.lower().replace('processor', ''))
             validation_result = FileValidator.validate_for_processor(
                 file_path, processor_type.lower().replace('processor', ''), max_size
@@ -167,10 +167,10 @@ class ProcessorFactory:
             if not validation_result["is_valid"]:
                 raise FileTypeError(f"파일 검증 실패: {', '.join(validation_result['errors'])}")
             
-            # 파일 처리
+            # Process file
             result = processor.process(file_path, output_format, **kwargs)
 
-            # PDF 처리 실패 또는 텍스트 부족 시 OCR 폴백
+            # Fallback to OCR if PDF processing fails or text is insufficient
             if (
                 isinstance(processor, PDFProcessor)
                 and self.config.pdf_config.USE_OCR_FALLBACK
@@ -181,7 +181,7 @@ class ProcessorFactory:
                 )
             ):
                 logger.info(
-                    "PDF 처리 결과가 부족하여 OCR 폴백을 수행합니다",
+                    "PDF processing result insufficient, falling back to OCR",
                     extra={"file_path": file_path},
                 )
                 ocr_proc = self.get_processor(file_path, "ocr")
@@ -192,7 +192,7 @@ class ProcessorFactory:
             
             processing_time = time.time() - start_time
             
-            # 처리 완료 로그
+            # Log processing completion
             log_processing_end(
                 logger, file_path, processor_type, True, processing_time,
                 file_size_mb=validation_result["file_info"]["size_mb"]
@@ -203,7 +203,7 @@ class ProcessorFactory:
         except Exception as e:
             processing_time = time.time() - start_time
             
-            # 처리 실패 로그
+            # Log processing failure
             log_processing_end(
                 logger, file_path, "unknown", False, processing_time,
                 error_message=str(e)
@@ -212,11 +212,11 @@ class ProcessorFactory:
             raise
     
     def get_supported_extensions(self) -> List[str]:
-        """지원하는 모든 파일 확장자를 반환합니다."""
+        """Return all supported file extensions."""
         return list(self._extension_mapping.keys())
     
     def get_processor_info(self) -> Dict[str, Any]:
-        """프로세서 정보를 반환합니다."""
+        """Return processor information."""
         return {
             "supported_extensions": self.get_supported_extensions(),
             "processor_types": list(self._processor_types.keys()),
@@ -231,20 +231,20 @@ class ProcessorFactory:
         }
 
 
-# 전역 팩토리 인스턴스
+# Global factory instance
 _default_factory: Optional[ProcessorFactory] = None
 
 
 def get_default_factory() -> ProcessorFactory:
-    """기본 프로세서 팩토리를 반환합니다."""
+    """Return the default processor factory."""
     global _default_factory
     if _default_factory is None:
         _default_factory = ProcessorFactory()
     return _default_factory
 
 
-def process_file(file_path: str, output_format: str = "markdown", 
+def process_file(file_path: str, output_format: str = "markdown",
                 force_processor: Optional[str] = None, **kwargs) -> Dict[str, Any]:
-    """편의 함수: 파일을 처리합니다."""
+    """Convenience function to process a file."""
     factory = get_default_factory()
     return factory.process_file(file_path, output_format, force_processor, **kwargs) 

--- a/tests/test_processor_factory.py
+++ b/tests/test_processor_factory.py
@@ -98,7 +98,7 @@ def test_get_processor_pdf_with_patch(tmp_path, monkeypatch):
 
 
 def test_process_file_pdf_fallback(tmp_path, monkeypatch):
-    """PDF 프로세서 실패 시 OCR로 폴백되는지 확인"""
+    """Verify OCR fallback when PDF processor fails"""
     file_path = tmp_path / "fail.pdf"
     file_path.write_bytes(b"%PDF-1.4\n")
 


### PR DESCRIPTION
## Summary
- translate Korean comments and docstrings to English
- update processor factory/mcp server modules
- clean up requirements comments
- provide improved English README and new Korean README
- adjust test docstring

## Testing
- `pytest -q` *(fails: ImportError: failed to find libmagic)*

------
https://chatgpt.com/codex/tasks/task_e_6847bc515c048322a39aa8021b70ddb8