### PR TITLE
Load .env automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ dependencies = [
     "pdf2image>=1.17.0",
     "Pillow>=10.0.0",
     "google-generativeai>=0.3.0",
-    "python-magic-bin>=0.4.14",
+    "python-magic>=0.4.27",
     "chardet>=5.2.0",
     "asyncio-throttle>=1.0.0",
     "pydantic>=2.5.0",
-    "structlog>=23.0.0"
+    "structlog>=23.0.0",
+    "python-dotenv>=1.0.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ pydantic>=2.5.0
 
 # Logging
 structlog>=23.0.0
+python-dotenv>=1.0.0
 
 # Development dependencies (optional)
 pytest>=7.4.0

--- a/src/document_reader/mcp_server.py
+++ b/src/document_reader/mcp_server.py
@@ -3,6 +3,14 @@
 import asyncio
 from typing import Dict, Any, Optional, List
 import json
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(dotenv_path=Path(__file__).resolve().parents[2] / ".env")
+except Exception:  # noqa: BLE001
+    pass
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import Tool, TextContent


### PR DESCRIPTION
## Summary
- load variables from a `.env` file on startup
- add `python-dotenv` dependency
- change `python-magic-bin` to `python-magic` for cross-platform compatibility

## Testing
- `pip install -e .[development]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a96b7f0388322aa96d34c11edffc4