### PR TITLE
Fix process_file with extra kwargs

### DIFF
--- a/src/document_reader/processors/base_processor.py
+++ b/src/document_reader/processors/base_processor.py
@@ -13,8 +13,16 @@ class BaseProcessor(ABC):
         logger.info(f"Initialized {self.name}")
 
     @abstractmethod
-    def process(self, file_path: str, output_format: str = "markdown") -> Dict[str, Any]:
-        """Process file and Returns Result"""
+    def process(
+        self, file_path: str, output_format: str = "markdown", **kwargs
+    ) -> Dict[str, Any]:
+        """Process file and return the result.
+
+        ``kwargs`` are ignored by processors that do not support additional
+        parameters.  This makes it safe to pass optional arguments (for
+        example ``user_language`` for the OCR processor) without raising a
+        ``TypeError``.
+        """
         pass
     
     @abstractmethod

--- a/src/document_reader/processors/csv_processor.py
+++ b/src/document_reader/processors/csv_processor.py
@@ -71,7 +71,14 @@ class CSVProcessor(BaseProcessor):
     def get_supported_extensions(self) -> List[str]:  # noqa: D401
         return list(self._supported_extensions)
 
-    def process(self, file_path: str, output_format: str = "markdown") -> Dict[str, Any]:  # noqa: D401
+    def process(
+        self, file_path: str, output_format: str = "markdown", **kwargs
+    ) -> Dict[str, Any]:  # noqa: D401
+        """Process a CSV file.
+
+        Extra keyword arguments are accepted for API compatibility but ignored.
+        """
+
         start_time = time.time()
 
         try:

--- a/src/document_reader/processors/ocr_processor.py
+++ b/src/document_reader/processors/ocr_processor.py
@@ -397,9 +397,18 @@ class OCRProcessor(BaseProcessor):
     def get_supported_extensions(self) -> List[str]:
         return self._supported_extensions
     
-    def process(self, file_path: str, output_format: str = "markdown", 
-                user_language: str = "auto") -> Dict[str, Any]:
-        """Synchronous wrapper for async processing"""
+    def process(
+        self,
+        file_path: str,
+        output_format: str = "markdown",
+        user_language: str = "auto",
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Synchronous wrapper for async processing.
+
+        ``kwargs`` are ignored to maintain API compatibility with other
+        processors.
+        """
         try:
             logger.info(
                 "Starting document processing", 

--- a/src/document_reader/processors/pdf_processor.py
+++ b/src/document_reader/processors/pdf_processor.py
@@ -24,8 +24,15 @@ class PDFProcessor(BaseProcessor):
     def get_supported_extensions(self) -> List[str]:
         return self._supported_extensions
     
-    def process(self, file_path: str, output_format: str = "markdown") -> Dict[str, Any]:
-        """Process PDF with native text extraction only"""
+    def process(
+        self, file_path: str, output_format: str = "markdown", **kwargs
+    ) -> Dict[str, Any]:
+        """Process PDF with native text extraction only.
+
+        ``kwargs`` are ignored so that callers can pass optional parameters
+        (e.g. ``user_language`` used by the OCR processor) without causing a
+        ``TypeError`` when this processor is selected.
+        """
         start_time = time.time()
 
         try:


### PR DESCRIPTION
## Summary
- support extra kwargs in BaseProcessor.process
- accept and ignore extra kwargs in CSV, PDF and OCR processors

## Testing
- `pip install -q -r requirements.txt` *(fails: No matching distribution found for pdf2image>=3.1.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'magic')*

------
https://chatgpt.com/codex/tasks/task_e_684aaa279dec8322824536e99e40f22b