### PR TITLE
Fix blocking CSV processing and add timeouts

### DIFF
--- a/src/document_reader/core/utils.py
+++ b/src/document_reader/core/utils.py
@@ -1,0 +1,30 @@
+"""Utility helpers for processors."""
+
+from __future__ import annotations
+
+import signal
+from functools import wraps
+
+
+def with_timeout(seconds: int):
+    """Decorator to abort a function if it exceeds the given timeout."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            def handler(signum, frame):
+                raise TimeoutError(
+                    f"Processing timeout after {seconds} seconds"
+                )
+
+            signal.signal(signal.SIGALRM, handler)
+            signal.alarm(seconds)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+
+        return wrapper
+
+    return decorator
+

--- a/src/document_reader/processors/pdf_processor.py
+++ b/src/document_reader/processors/pdf_processor.py
@@ -7,6 +7,7 @@ import time
 
 import fitz
 from .base_processor import BaseProcessor
+from ..core.utils import with_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ class PDFProcessor(BaseProcessor):
     def get_supported_extensions(self) -> List[str]:
         return self._supported_extensions
     
+    @with_timeout(60)
     def process(
         self, file_path: str, output_format: str = "markdown", **kwargs
     ) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- avoid nested event loops in `CSVProcessor` by converting async helpers to sync
- add a common `with_timeout` decorator and use it in CSV/PDF/OCR processors
- run OCR async processing in a background thread

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_684c09c1e36c8322ad73e999df2bcd86