### PR TITLE
Enhance API and add Excel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 </p>
 
-Universal File Reader is an MCP server for extracting text and structural information from PDF, CSV and image files. The server automatically selects the appropriate processor and can fall back to OCR when needed.
+Universal File Reader is an MCP server for extracting text and structural information from PDF, CSV, Excel and image files. The server automatically selects the appropriate processor and can fall back to OCR when needed.
 
 ## Installation
 
@@ -35,10 +35,11 @@ The server exposes three tools: `read_file`, `get_supported_formats` and `valida
 
 ## Running the API server
 
-You can also start a REST API that wraps the same functionality. The service exposes two endpoints:
+You can also start a REST API that wraps the same functionality. The service exposes three endpoints:
 
 - `POST /mcp` – accept MCP JSON messages
-- `POST /upload` – simple file upload
+- `POST /upload` – upload a file and receive the server path
+- `POST /test` – upload a file and process it with optional parameters
 
 Start the server locally:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@ pdf2image>=1.17.0
 # Image handling
 Pillow>=10.0.0
 
+# Excel support
+openpyxl>=3.1.2
+
 # OCR and AI
 google-generativeai>=0.3.0
 

--- a/src/document_reader/api_server.py
+++ b/src/document_reader/api_server.py
@@ -9,7 +9,13 @@ from pydantic import BaseModel, Field
 from .mcp_server import call_tool, mcp_server
 
 
-app = FastAPI()
+async def lifespan(app: FastAPI):
+    if not mcp_server.initialized:
+        await mcp_server.initialize()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 class MCPRequest(BaseModel):
     """Schema for MCP JSON requests."""
@@ -21,11 +27,6 @@ class MCPRequest(BaseModel):
     )
 
 
-@app.on_event("startup")
-async def startup_event() -> None:
-    """Initialize the underlying MCP server once."""
-    if not mcp_server.initialized:
-        await mcp_server.initialize()
 
 
 @app.post("/mcp")
@@ -43,7 +44,7 @@ async def receive_mcp(request: MCPRequest) -> Dict[str, Any]:
 
 @app.post("/upload")
 async def upload_file(file: UploadFile = File(...)) -> Dict[str, Any]:
-    """Upload a file and process it using the MCP server."""
+    """Upload a file and return the server path."""
     contents = await file.read()  # noqa: WPS110
     temp_path = f"/tmp/{file.filename}"
     with open(temp_path, "wb") as tmp:
@@ -51,10 +52,33 @@ async def upload_file(file: UploadFile = File(...)) -> Dict[str, Any]:
 
     logging.info("Uploaded file %s with %d bytes", file.filename, len(contents))
 
+    return {"file_path": temp_path}
+
+
+@app.post("/test")
+async def test_file(
+    file: UploadFile = File(...),
+    output_format: str = "markdown",
+    force_processor: str | None = None,
+    user_language: str = "auto",
+) -> Dict[str, Any]:
+    """Upload a file and process it using the MCP server."""
+    contents = await file.read()  # noqa: WPS110
+    temp_path = f"/tmp/{file.filename}"
+    with open(temp_path, "wb") as tmp:
+        tmp.write(contents)
+
+    logging.info("Testing file %s with %d bytes", file.filename, len(contents))
+
     try:
         result = await call_tool(
             "read_file",
-            {"file_path": temp_path, "output_format": "markdown"},
+            {
+                "file_path": temp_path,
+                "output_format": output_format,
+                "force_processor": force_processor,
+                "user_language": user_language,
+            },
         )
     finally:
         try:

--- a/src/document_reader/core/config.py
+++ b/src/document_reader/core/config.py
@@ -42,6 +42,7 @@ class OCRConfig:
     MIN_DPI: int = 150
     MAX_PAGES: int = 10
     MAX_PAGE_PER_PROCESS: int = 5
+    TIMEOUT_SECONDS: int = 60
     COMPRESSION_QUALITY: int = 85
     SUPPORTED_LANGUAGES: Dict[str, str] = field(default_factory=lambda: {
         "ko": "Korean", "en": "English", "ja": "Japanese", 
@@ -89,6 +90,9 @@ class ProcessorConfig:
 
         if timeout := os.getenv('TIMEOUT_SECONDS'):
             config.global_config.TIMEOUT_SECONDS = int(timeout)
+
+        if ocr_timeout := os.getenv('OCR_TIMEOUT_SECONDS'):
+            config.ocr_config.TIMEOUT_SECONDS = int(ocr_timeout)
 
         return config
     

--- a/src/document_reader/processor_factory.py
+++ b/src/document_reader/processor_factory.py
@@ -10,6 +10,7 @@ from .processors.base_processor import BaseProcessor
 from .processors.csv_processor import CSVProcessor
 from .processors.pdf_processor import PDFProcessor
 from .processors.ocr_processor import OCRProcessor
+from .processors.excel_processor import ExcelProcessor
 
 from .core.config import ProcessorConfig
 from .core.validators import FileValidator, SecurityValidator
@@ -32,6 +33,7 @@ class ProcessorFactory:
             "csv": CSVProcessor,
             "pdf": PDFProcessor,
             "ocr": OCRProcessor,
+            "excel": ExcelProcessor,
         }
         self._extension_mapping = self._build_extension_mapping()
 
@@ -42,6 +44,10 @@ class ProcessorFactory:
         # CSV files
         for ext in [".csv", ".tsv"]:
             mapping[ext] = "csv"
+
+        # Excel files
+        for ext in [".xlsx", ".xls"]:
+            mapping[ext] = "excel"
 
         # PDF files - choose between OCR and PDF processor
         mapping[".pdf"] = "auto"  # choose automatically

--- a/src/document_reader/processors/__init__.py
+++ b/src/document_reader/processors/__init__.py
@@ -1,0 +1,5 @@
+from .csv_processor import CSVProcessor
+from .excel_processor import ExcelProcessor
+from .pdf_processor import PDFProcessor
+from .ocr_processor import OCRProcessor
+

--- a/src/document_reader/processors/excel_processor.py
+++ b/src/document_reader/processors/excel_processor.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import numpy as np
+
+from .csv_processor import CSVProcessor, CSVConfig
+from ..core.models import ColumnInfo, CSVAnalysis, CSVResult
+from ..core.exceptions import CSVError, FileSizeError
+from ..core.utils import with_timeout
+
+logger = logging.getLogger(__name__)
+
+
+class ExcelProcessor(CSVProcessor):
+    """Processor for Excel files using pandas."""
+
+    _supported_extensions = {".xlsx", ".xls"}
+
+    def __init__(self, config: Optional[CSVConfig] = None) -> None:
+        super().__init__(config)
+
+    def supports(self, file_extension: str) -> bool:  # noqa: D401
+        return file_extension.lower() in self._supported_extensions
+
+    def get_supported_extensions(self) -> List[str]:  # noqa: D401
+        return list(self._supported_extensions)
+
+    def _validate_file(self, file_path: str) -> bool:  # noqa: D401
+        path = Path(file_path)
+        if not path.exists() or not path.is_file():
+            raise FileNotFoundError(file_path)
+
+        size_mb = path.stat().st_size / (1024 * 1024)
+        if size_mb > self.config.MAX_FILE_SIZE_MB:
+            raise FileSizeError(
+                f"File too large: {size_mb:.1f} MB (limit {self.config.MAX_FILE_SIZE_MB} MB)"
+            )
+
+        if path.suffix.lower() not in self._supported_extensions:
+            raise CSVError(f"Unsupported extension: {path.suffix}")
+
+        return True
+
+    @with_timeout(30)
+    def process(
+        self, file_path: str, output_format: str = "markdown", **kwargs: Any
+    ) -> Dict[str, Any]:
+        """Process an Excel file and return results."""
+        import time
+
+        start_time = time.time()
+        try:
+            if not self._validate_file(file_path):
+                raise CSVError("File validation failed")
+
+            df = pd.read_excel(file_path)
+            preview_df = df.head(self.config.MAX_ROWS_PREVIEW)
+            column_info: List[ColumnInfo] = []
+            type_summary: Dict[str, int] = {}
+            for col in df.columns[: self.config.MAX_COLUMNS]:
+                col_data = df[col]
+                dtype_str = str(col_data.dtype)
+                type_summary[dtype_str] = type_summary.get(dtype_str, 0) + 1
+                column_info.append(
+                    ColumnInfo(
+                        name=col,
+                        dtype=dtype_str,
+                        non_null_count=int(col_data.count()),
+                        null_count=int(col_data.isnull().sum()),
+                        unique_count=int(col_data.nunique()),
+                        sample_values=col_data.dropna()
+                        .astype(str)
+                        .unique()[:5]
+                        .tolist(),
+                    )
+                )
+
+            mem_mb = df.memory_usage(deep=True).sum() / (1024 * 1024)
+            analysis = CSVAnalysis(
+                file_path=file_path,
+                file_size_mb=Path(file_path).stat().st_size / (1024 * 1024),
+                encoding="binary",
+                total_rows=len(df),
+                total_columns=len(df.columns),
+                column_info=column_info,
+                data_types_summary=type_summary,
+                memory_usage_mb=mem_mb,
+                has_header=True,
+                delimiter=",",
+                processing_time=time.time() - start_time,
+            )
+
+            numeric_cols = df.select_dtypes(include=[np.number])
+            summary_stats = (
+                numeric_cols.describe().to_dict() if not numeric_cols.empty else {}
+            )
+            result = CSVResult(
+                analysis=analysis,
+                preview_data=preview_df.to_markdown(index=False),
+                summary_stats=summary_stats,
+            )
+
+            if output_format == "structured":
+                formatted_output: Any = result.model_dump()
+            elif output_format == "markdown":
+                formatted_output = self._format_as_markdown(result, file_path)
+            else:
+                formatted_output = self._format_as_html(result, file_path)
+
+            return self._create_success_response(
+                formatted_output,
+                file_path,
+                processing_method="Excel analysis",
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("Excel processing failed: %s", exc)
+            return self._create_error_response(str(exc), file_path)


### PR DESCRIPTION
## Summary
- add ExcelProcessor and wire it into processor factory
- allow configuration for OCR timeout
- update API server with lifespan startup and new `/test` endpoint
- change `/upload` to just upload and return path
- add openpyxl dependency
- document API changes and Excel support in README

## Testing
- `ruff check` *(fails: E402 etc.)*
- `pytest -q` *(fails: ImportError: failed to find libmagic)*

------
https://chatgpt.com/codex/tasks/task_e_684c3b70aa248322a7e2cfdd9ca6ec60